### PR TITLE
Put benchmarks in functions

### DIFF
--- a/client.jl
+++ b/client.jl
@@ -1,4 +1,4 @@
-using ZMQ
+include("client_funcs.jl")
 
 if (length(ARGS) != 2)
   println("Usage: julia client.jl server_ip server_port")
@@ -6,62 +6,42 @@ if (length(ARGS) != 2)
 end
 
 ip = ARGS[1]
-port = int32(ARGS[2])
+port = parse(Int32, ARGS[2])
 
 ctx = Context(1)
 s = Socket(ctx, ROUTER)
 ZMQ.set_identity(s, "client_id")
 ZMQ.connect(s, "tcp://$ip:$port")
 
-# Phase 1: latency test.
-tic()
 num_iters = 1000
-for i = 1:num_iters
-  io = IOBuffer()
-  if (i == num_iters)
-    write(io, int8(42), false)
-  else
-    write(io, int8(42), true)
-  end
-  ZMQ.send(s, "server_id", SNDMORE)
-  ZMQ.send(s, Message(io))
 
-  # Receive ack from server.
-  sender = bytestring(ZMQ.recv(s))
-  @assert(sender == "server_id", "Received msg from unknown client $sender")
-  msg = ZMQ.recv(s)
-  @assert(bytestring(msg) == "ack", "Expecting 'ack', but got $ret_msg")
-end
+Base.precompile(latency, (typeof(s), Int))
+
+# Phase 1: Latency test
+println("Client entering latency test")
+tic()
+latency(s, num_iters)
 time = toq()
 println("Latency: $(time / num_iters)s")
 
 
 # Phase 2: Throughput test
-println("Client entering phase 2")
 num_bytes = 2^14  # 16KB
-A = Array(Uint8, num_bytes)
+A = Array(UInt8, num_bytes)
 for i = 1:num_bytes
-  A[i] = i % typemax(Uint8)
+  A[i] = i % typemax(UInt8)
 end
 
 io = IOBuffer()
-write(io, true, int32(num_bytes), A)
+write(io, true, Int32(num_bytes), A)
 io2 = IOBuffer()
-write(io2, false, int32(num_bytes), A)
+write(io2, false, Int32(num_bytes), A)
+
+Base.precompile(throughput, (typeof(s), typeof(io), typeof(io2), Int))
+
+println("Client entering throughput test")
 tic()
-for i = 1:num_iters
-  ZMQ.send(s, "server_id", SNDMORE)
-  if (i == num_iters)
-    ZMQ.send(s, Message(io2))
-  else
-    ZMQ.send(s, Message(io))
-  end
-end
-# Receive final ack from server.
-sender = bytestring(ZMQ.recv(s))
-@assert(sender == "server_id", "Received msg from unknown client $sender")
-ack_msg = bytestring(ZMQ.recv(s))
-@assert(ack_msg == "ack", "Expecting 'ack', but got $ack_msg")
+throughput(s, io, io2, num_iters)
 time = toq()
 println(string("Throughput: $(num_bytes * num_iters / time) bytes/s ",
 "($num_iters msgs, time: $time)"))

--- a/client_funcs.jl
+++ b/client_funcs.jl
@@ -1,0 +1,39 @@
+using ZMQ
+
+# Phase 1: latency test.
+function latency(s, num_iters)
+    io = IOBuffer()
+    for i = 1:num_iters
+        truncate(io, 0)
+        if (i == num_iters)
+            write(io, Int8(42), false)
+        else
+            write(io, Int8(42), true)
+        end
+        ZMQ.send(s, "server_id", SNDMORE)
+        ZMQ.send(s, Message(io))
+
+        # Receive ack from server.
+        sender = bytestring(ZMQ.recv(s))
+        @assert(sender == "server_id", "Received msg from unknown client $sender")
+        msg = ZMQ.recv(s)
+        ret_msg = bytestring(msg)
+        @assert(ret_msg == "ack", "Expecting 'ack', but got $ret_msg")
+    end
+end
+
+function throughput(s, io, io2, num_iters)
+    for i = 1:num_iters
+        ZMQ.send(s, "server_id", SNDMORE)
+        if (i == num_iters)
+            ZMQ.send(s, Message(io2))
+        else
+            ZMQ.send(s, Message(io))
+        end
+    end
+    # Receive final ack from server.
+    sender = bytestring(ZMQ.recv(s))
+    @assert(sender == "server_id", "Received msg from unknown client $sender")
+    ack_msg = bytestring(ZMQ.recv(s))
+    @assert(ack_msg == "ack", "Expecting 'ack', but got $ack_msg")
+end

--- a/server.jl
+++ b/server.jl
@@ -1,61 +1,20 @@
-using ZMQ
+include("server_funcs.jl")
 
 if (length(ARGS) != 1)
   println("Usage: julia server.jl server_port")
   quit()
 end
 
-port = int32(ARGS[1])
+port = parse(Int32, ARGS[1])
 ctx = Context(1)
 s = Socket(ctx, ROUTER)
 ZMQ.set_identity(s, "server_id")
 ZMQ.bind(s, "tcp://*:$port")
 
-# Phase 1: latency test.
-cont = true
-while cont
-  #println("Server waiting for message")
-  sender = bytestring(ZMQ.recv(s))
-  @assert(sender == "client_id", "Received msg from unknown client $sender")
-  #println("Server got a message!")
-  msg = ZMQ.recv(s)
-  io = seek(convert(IOStream, msg), 0)
-  m = read(io, Int8)
-  @assert(m == 42, "Received corrupted message.")
-  cont = read(io, Bool)
-  ZMQ.send(s, "client_id", SNDMORE)
-  ZMQ.send(s, Message("ack"))
-end
-println("Server finished phase 1")
+Base.precompile(server_latency, (typeof(s),))
+Base.precompile(server_throughput, (typeof(s),))
 
-
-# Phase 2: Throughput test
-println("Server entering phase 2")
-cont = true
-correct_num_bytes = 2^14
-i = 0
-while cont
-  #println("Server waiting for message")
-  sender = bytestring(ZMQ.recv(s))
-  @assert(sender == "client_id", "Received msg from unknown client $sender")
-  msg = ZMQ.recv(s)
-  #println("Server got a message!")
-  io = seek(convert(IOStream, msg), 0)
-  cont = read(io, Bool)
-  num_bytes = read(io, Int32)
-  @assert(num_bytes == correct_num_bytes,
-  "Received corrupted message $num_bytes")
-
-  #A = map(ntoh, read(io, Uint8, num_bytes))
-  # Comment this out for a better network bandwidth assessment.
-  #for i = 1:num_bytes
-  #  @assert(A[i] == (i % typemax(Uint8)), "Message A is corrupted.")
-  #end
-  i = i + 1
-  #println("Bytes verified")
-end
-ZMQ.send(s, "client_id", SNDMORE)
-ZMQ.send(s, Message("ack"))
-println("Server finished phase 2. Received $i msgs.")
+server_latency(s)
+server_throughput(s)
 
 println("Server shutdown")

--- a/server_funcs.jl
+++ b/server_funcs.jl
@@ -1,0 +1,54 @@
+using ZMQ
+
+# Phase 1: latency test.
+function server_latency(s)
+    println("Server entering phase 1")
+    cont = true
+    while cont
+        #println("Server waiting for message")
+        sender = bytestring(ZMQ.recv(s))
+        @assert(sender == "client_id", "Received msg from unknown client $sender")
+        #println("Server got a message!")
+        msg = ZMQ.recv(s)
+        io = seek(convert(IOStream, msg), 0)
+        m = read(io, Int8)
+        @assert(m == 42, "Received corrupted message.")
+        cont = read(io, Bool)
+        ZMQ.send(s, "client_id", SNDMORE)
+        ZMQ.send(s, Message("ack"))
+    end
+    println("Server finished phase 1")
+    nothing
+end
+
+# Phase 2: Throughput test
+function server_throughput(s)
+    println("Server entering phase 2")
+    cont = true
+    correct_num_bytes = 2^14
+    i = 0
+    while cont
+        #println("Server waiting for message")
+        sender = bytestring(ZMQ.recv(s))
+        @assert(sender == "client_id", "Received msg from unknown client $sender")
+        msg = ZMQ.recv(s)
+        #println("Server got a message!")
+        io = seek(convert(IOStream, msg), 0)
+        cont = read(io, Bool)
+        num_bytes = read(io, Int32)
+        @assert(num_bytes == correct_num_bytes,
+                "Received corrupted message $num_bytes")
+
+        #A = map(ntoh, read(io, Uint8, num_bytes))
+        # Comment this out for a better network bandwidth assessment.
+        #for i = 1:num_bytes
+        #  @assert(A[i] == (i % typemax(Uint8)), "Message A is corrupted.")
+        #end
+        i = i + 1
+        #println("Bytes verified")
+    end
+    ZMQ.send(s, "client_id", SNDMORE)
+    ZMQ.send(s, Message("ack"))
+    println("Server finished phase 2. Received $i msgs.")
+    nothing
+end


### PR DESCRIPTION
This version gives very similar performance to the 0MQ benchmarks. The main tricks are to (1) put performance-sensitive code in functions, and (2) make sure the functions are JIT-compiled before you use them (so you're not including compilation time in the benchmark).

This probably only works on julia 0.4, but the tweaks for 0.3 are small.
